### PR TITLE
fix testnet support: don't try to store legacy events

### DIFF
--- a/src/db_adapters/coin/legacy/mod.rs
+++ b/src/db_adapters/coin/legacy/mod.rs
@@ -13,7 +13,12 @@ pub(crate) async fn collect_legacy(
     shard_id: &near_indexer_primitives::types::ShardId,
     receipt_execution_outcomes: &[near_indexer_primitives::IndexerExecutionOutcomeWithReceipt],
     block_header: &near_indexer_primitives::views::BlockHeaderView,
+    chain_id: &str,
 ) -> anyhow::Result<Vec<CoinEvent>> {
+    // We don't need to store legacy events for testnet
+    if chain_id == "testnet" {
+        return Ok(vec![]);
+    }
     let mut events: Vec<CoinEvent> = vec![];
 
     let aurora_future = aurora::collect_aurora(shard_id, receipt_execution_outcomes, block_header);

--- a/src/db_adapters/events.rs
+++ b/src/db_adapters/events.rs
@@ -6,9 +6,10 @@ use near_lake_framework::near_indexer_primitives;
 pub(crate) async fn store_events(
     pool: &sqlx::Pool<sqlx::Postgres>,
     streamer_message: &near_indexer_primitives::StreamerMessage,
+    chain_id: &str,
 ) -> anyhow::Result<()> {
     try_join!(
-        coin::store_ft(pool, streamer_message,),
+        coin::store_ft(pool, streamer_message, chain_id),
         nft::store_nft(pool, streamer_message),
     )?;
     Ok(())


### PR DESCRIPTION
Aurora makes evil experiments on testnet and we crash on it (for mainnet, everything works fine).
I suggest stopping even trying to store any legacy events on testnet.
Testnet support is intended to help the developers testing their solution. We need to encourage everyone to use nep141-compatible events.